### PR TITLE
Embed alias definition instead of using 'include::' 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,11 +21,22 @@ Followings will be required to run `jf`
 * `bash`
 
 === With Docker
+Add a following entry to your `.bashrc` or a file sourced through it.
 
-Add the following entry to your `.bashrc` or a file sourced through it.
 [source, bash]
-include::jf_aliases[]
-
+----
+function jf() {
+  local _target=${1}
+  local _jf_path
+  docker run -i \
+    -v /:/var/lib/jf \
+    -e JF_PATH_BASE="/var/lib/jf" \
+    -e JF_PATH="${JF_PATH}" \
+    -e JF_DEBUG=${JF_DEBUG} \
+    -e JF_CWD="$(pwd)" \
+    dakusui/jf "${@}"
+}
+----
 
 
 == Usage


### PR DESCRIPTION
Embed alias definition instead of using 'include::' since it is not rendered by github's .adoc handler. (Linking also didn't work, either) (Issue #12 )